### PR TITLE
Fix config/initializer path typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ gem 'safe_redirect'
 
 ##  Configuration
 
-Create a `config/initializer/safe_redirect.rb` file.
+Create a `config/initializers/safe_redirect.rb` file.
 
 ```rb
 SafeRedirect.configure do |config|


### PR DESCRIPTION
In Rails apps, the existing directory is `config/initializers` -- this fixes the typo. Thanks!